### PR TITLE
docs(no-constructor): fix layout & wording

### DIFF
--- a/docs/rules/no-constructor.md
+++ b/docs/rules/no-constructor.md
@@ -1,8 +1,23 @@
 # No Constructor
 
-This rule disallows using the `constructor` in a HTMLElement class.
+Classes can use the `constructor` method to execute behaviours upon creation of their object. This is useful for things like initialisation of private state. Custom Elements also have other lifecycle callbacks which can be used for this, such as `connectedCallback`.
+
+For Custom Elements, the `constructor` method can be a little unwieldy to use; it is called as soon as the class is instantiated with `document.createElement` which will be _before_ the element has been appended to the DOM. It can be simpler to put code within the `connectedCallback` which is fired when the element has been appended into the DOM.
+
+Many expectations from an element are not true during the `constructor` call. For example you cannot:
+
+ - read any attributes on the element (`.attributes` will always be an empty `NamedNodeMap`).
+ - access any child elements (`.children` will always be an empty `HTMLCollection`).
+ - Fire events that bubble. As the node is not connected it cannot bubble.
+
+Also, there are many edge cases that can cause complications inside the constructor, for example:
+
+ - Creating child elements and appending them will cause _their_ connected callbacks to fire, but their parent (the current element) will be disconnected from the DOM.
+ - Changing attributes will cause `attributeChangedCallback` to fire, which may expect to be connected.
 
 ## Rule Details
+
+This rule disallows using the `constructor` in a HTMLElement class.
 
 👎 Examples of **incorrect** code for this rule:
 
@@ -24,21 +39,6 @@ class FooBar extends HTMLElement {
   }
 }
 ```
-
-The `constructor` method is a little unwieldy to use for subclasses. It is called as soon as the class is instantiated with `document.createElement` which will be _before_ the element has been appended to the DOM.
-
-It is better to put code within the `connectedCallback` which is fired when the element has been appended into the DOM.
-
-Many expectations from an element are not true during the `constructor` call. For example you cannot:
-
- - read any attributes on the element (`.attributes` will always be an empty `NamedNodeMap`).
- - access any child elements (`.children` will always be an empty `HTMLCollection`).
- - Fire events that bubble. As the node is not connected it cannot bubble.
-
-Also, there are many edge cases that can cause complications inside the constructor, for example:
-
- - Creating child elements and appending them will cause _their_ connected callbacks to fire, but their parent (the current element) will be disconnected from the DOM.
- - Changing attributes will cause `attributeChangedCallback` to fire, which may expect to be connected.
 
 ## When Not To Use It
 


### PR DESCRIPTION
The `No Constructor` docs have a layout which is different to the other docs.

The "standardised" layout per other docs: the main heading explains the problem, and the first sentence in `Rule Details` explains what the rule does. 

Currently `No Constructor` has the explanation of what the rule does under the main heading, and the explainer _below_ examples. This PR changes the layout to match the other docs.