### PR TITLE
Allow DOM traversal if scoped in certain scopes

### DIFF
--- a/lib/rules/no-dom-traversal-in-connectedcallback.js
+++ b/lib/rules/no-dom-traversal-in-connectedcallback.js
@@ -23,6 +23,9 @@ const methods = new Set([
   'removeChild',
   'replaceChild'
 ])
+
+const allowedScopes = new Set(['addEventListener', 'MutationObserver'])
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -32,7 +35,13 @@ module.exports = {
   create(context) {
     return {
       [`${s.HTMLElementClass} MethodDefinition[key.name="connectedCallback"] MemberExpression`](node) {
+        const scope = context.getScope()
+        if (scope.type === 'function') {
+          const functionScopeName = scope.block.parent.callee?.name || scope.block.parent.callee?.property?.name
+          if (allowedScopes.has(functionScopeName)) return
+        }
         const name = node.property.name
+
         if (node.parent.type === 'CallExpression' && node.parent.callee === node && methods.has(name)) {
           context.report(node.parent, `DOM traversal using .${name} inside connectedCallback() is error prone.`)
         }

--- a/test/no-dom-traversal-in-connectedcallback.js
+++ b/test/no-dom-traversal-in-connectedcallback.js
@@ -8,7 +8,34 @@ ruleTester.run('no-dom-traversal-in-connectedcallback', rule, {
     {code: 'document.querySelector("hello")'},
     {code: 'class FooBar { connectedCallback() { this.querySelector("hello") } }'},
     {code: 'class FooBar extends HTMLElement { update() { this.querySelector("hello") } }'},
-    {code: 'document.children'}
+    {code: 'document.children'},
+    {
+      code: `
+class FooBarElement extends HTMLElement {
+  connectedCallback() {
+    this.addEventListener("update", () => {
+      const button = this.querySelector('button')
+      if (button) {
+        button.disabled = true
+      }
+    })
+  }
+}
+`
+    },
+    {
+      code: `
+class FooBarElement extends HTMLElement {
+  connectedCallback() {
+    new MutationObserver(() => {
+      const button = this.querySelector('button')
+      if (button) {
+        button.disabled = true
+      }
+    }).observe(this)
+  }
+}`
+    }
   ],
   invalid: [
     {


### PR DESCRIPTION
The "correct usage for this rule" examples in the documentation for the `no-dom-traversal-in-connectedcallback` rule show errors when the rule is applied to them. This is because the documentation hints that certain "allowed" scopes that DOM traversal should be allowed in. But since these scopes aren't implemented in the rule, it will error on the examples.

This PR implements the allowed scopes (`addEventListener` and `MutationObserver`) and adds the "correct usage for this rule" examples to the test suite.