### PR TITLE
docs(no-constructor): fix indefinite article

### DIFF
--- a/docs/rules/no-constructor.md
+++ b/docs/rules/no-constructor.md
@@ -17,7 +17,7 @@ Also, there are many edge cases that can cause complications inside the construc
 
 ## Rule Details
 
-This rule disallows using the `constructor` in a HTMLElement class.
+This rule disallows using the `constructor` in an HTMLElement class.
 
 👎 Examples of **incorrect** code for this rule:
 


### PR DESCRIPTION
`an HTMLElement` is the proper indefinite article here.