### PR TITLE
Prevent calling HTML and text parsing properties in connectedCallback

### DIFF
--- a/lib/rules/no-dom-traversal-in-connectedcallback.js
+++ b/lib/rules/no-dom-traversal-in-connectedcallback.js
@@ -38,6 +38,8 @@ module.exports = {
   create(context) {
     return {
       [`${s.HTMLElementClass} MethodDefinition[key.name="connectedCallback"] MemberExpression`](node) {
+        if (node.parent.type === 'AssignmentExpression') return
+
         const scope = context.getScope()
         if (scope.type === 'function') {
           const functionScopeName = scope.block.parent.callee?.name || scope.block.parent.callee?.property?.name

--- a/test/no-dom-traversal-in-connectedcallback.js
+++ b/test/no-dom-traversal-in-connectedcallback.js
@@ -8,6 +8,7 @@ ruleTester.run('no-dom-traversal-in-connectedcallback', rule, {
     {code: 'document.querySelector("hello")'},
     {code: 'class FooBar { connectedCallback() { this.querySelector("hello") } }'},
     {code: 'class FooBar extends HTMLElement { update() { this.querySelector("hello") } }'},
+    {code: 'class FooBar extends HTMLElement { connectedCallback() { this.innerHTML = "<h1>foo</h1>" } }'},
     {code: 'document.children'},
     {
       code: `
@@ -35,6 +36,9 @@ class FooBarElement extends HTMLElement {
     }).observe(this)
   }
 }`
+    },
+    {
+      code: 'class FooBar extends HTMLElement { connectedCallback() { this.children = [1] } }'
     }
   ],
   invalid: [
@@ -67,15 +71,6 @@ class FooBarElement extends HTMLElement {
     },
     {
       code: 'class FooBar extends HTMLElement { connectedCallback() { this.children } }',
-      errors: [
-        {
-          message: 'DOM traversal using .children inside connectedCallback() is error prone.',
-          type: 'MemberExpression'
-        }
-      ]
-    },
-    {
-      code: 'class FooBar extends HTMLElement { connectedCallback() { this.children = [1] } }',
       errors: [
         {
           message: 'DOM traversal using .children inside connectedCallback() is error prone.',


### PR DESCRIPTION
`innerHTML`, `innerText` and `textContent` can all possibly be undefined when `connectedCallback` is called.