### PR TITLE
Make sure to only select direct AssignementExpressions.

### DIFF
--- a/lib/rules/no-exports-with-element.js
+++ b/lib/rules/no-exports-with-element.js
@@ -27,7 +27,7 @@ module.exports = {
           exports.add(node)
         }
       },
-      ['ExportNamedDeclaration AssignmentExpression']: function (node) {
+      ['ExportNamedDeclaration > AssignmentExpression']: function (node) {
         if (!classes.get(node.right)) {
           exports.add(node.right)
         }

--- a/test/no-exports-with-element.js
+++ b/test/no-exports-with-element.js
@@ -20,6 +20,9 @@ ruleTester.run('no-exports-with-element', rule, {
         'class FooBarElement extends HTMLElement { }\nclass BarFooElement extends HTMLElement { }\nexport {FooBarElement}\nexport {BarFooElement}'
     },
     {
+      code: 'export class FooBarElement extends HTMLElement { connectedCallback() { window.a = 1; } }'
+    },
+    {
       code: `class FooBarElement extends HTMLElement { }
 export {FooBarElement}
 class BarFooElement extends HTMLElement { }


### PR DESCRIPTION
We want to make sure only to select direct AssignmentExpressions rather than any AssignmentExpression in the custom element.