### PR TITLE
Add requirements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is an ESLint Plugin to help provide best practices for writing Custom Elements aka Web Components. It provides a set of custom rules which can be enforced for files that declare classes that extend from HTMLElement.
 
+## Requirements
+
+Node 14.x
+
 ## Installation
 
 ```sh


### PR DESCRIPTION
We're using the optional chaining operator in the project. Node 14 implemented the optional chaining operator. We should let users know about this requirement to prevent confusion if the project crashes on other node versions.

## References
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
https://nodejs.org/en/about/releases/