### PR TITLE
Configs with plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ $ npm install --save-dev eslint eslint-plugin-custom-elements
 
 ## Setup
 
-Add `custom-elements` to your list of plugins in your ESLint config, and `plugin:custom-elements/recommended` to the `extends` array.
+Add `custom-elements` to your list of plugins in your ESLint config, and enable the rules you want or just add `plugin:custom-elements/recommended` to the `extends` array.
 
 JSON ESLint config example:
 
 ```json
 {
-  "plugins": ["custom-elements"],
   "extends": ["plugin:custom-elements/recommended"]
 }
 ```

--- a/lib/configs/minimal.js
+++ b/lib/configs/minimal.js
@@ -6,6 +6,7 @@ module.exports = {
   env: {
     es2021: true
   },
+  plugins: ['custom-elements'],
   rules: Object.fromEntries(
     Object.keys(rules)
       .filter(r => rules[r].meta.type === 'problem')

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -6,5 +6,6 @@ module.exports = {
   env: {
     es2021: true
   },
+  plugins: ['custom-elements'],
   rules: Object.fromEntries(Object.keys(rules).map(r => [`custom-elements/${r}`, 'error']))
 }


### PR DESCRIPTION
As per the examples in https://eslint.org/docs/developer-guide/working-with-plugins#configs-in-plugins , configs can add `plugins` for users automatically.