### PR TITLE
Only allow string literal as tag name values.

### DIFF
--- a/lib/rules/valid-tag-name.js
+++ b/lib/rules/valid-tag-name.js
@@ -25,6 +25,8 @@ module.exports = {
       [s.customElements.define](node) {
         const nameArg = node.arguments[0]
         let name = nameArg.value
+        // Give up if there's no value to report on
+        if (!name) return
         if (nameArg.type === 'TemplateLiteral') {
           // Give up on TemplateLiteral expressions
           if (nameArg.expressions.length) return

--- a/lib/rules/valid-tag-name.js
+++ b/lib/rules/valid-tag-name.js
@@ -25,8 +25,10 @@ module.exports = {
       [s.customElements.define](node) {
         const nameArg = node.arguments[0]
         let name = nameArg.value
-        // Give up if there's no value to report on
-        if (!name) return
+        if (!['Literal', 'TemplateLiteral'].includes(nameArg.type)) {
+          context.report(nameArg, 'Expected custom element name to be a string literal')
+          return
+        }
         if (nameArg.type === 'TemplateLiteral') {
           // Give up on TemplateLiteral expressions
           if (nameArg.expressions.length) return

--- a/test/valid-tag-name.js
+++ b/test/valid-tag-name.js
@@ -19,6 +19,15 @@ ruleTester.run('valid-tag-name', rule, {
   ],
   invalid: [
     {
+      code: 'const tagName = "foo-bar"; customElements.define(tagName)',
+      errors: [
+        {
+          message: 'Expected custom element name to be a string literal',
+          type: 'Identifier'
+        }
+      ]
+    },
+    {
       code: 'customElements.define("foo")',
       errors: [
         {


### PR DESCRIPTION
This is to prevent the rule from blowing up if there's no value property on the first argument such as if the argument is an expression.

```js
const tagName = 'my-cool-element'

window.customElements.define(tagName, class extends HTMLElement)
```