### PR TITLE
Allow for HTML elements of the structure VendorHTMLElement

### DIFF
--- a/lib/class-ref-tracker.js
+++ b/lib/class-ref-tracker.js
@@ -46,7 +46,7 @@ class ClassRefTracker {
   }
 
   static customElements(context) {
-    return new ClassRefTracker(context, superClassRef => superClassRef && /^HTML.*Element$/.test(superClassRef.name))
+    return new ClassRefTracker(context, superClassRef => superClassRef && /^.*HTML.*Element$/.test(superClassRef.name))
   }
 }
 

--- a/lib/custom-selectors.js
+++ b/lib/custom-selectors.js
@@ -1,4 +1,4 @@
-const HTMLElementClass = ':matches(ClassDeclaration, ClassExpression)[superClass.name=/HTML.*Element/]'
+const HTMLElementClass = ':matches(ClassDeclaration, ClassExpression)[superClass.name=/.*HTML.*Element/]'
 const customElements = {
   _call:
     '[callee.object.type=Identifier][callee.object.name=customElements],' +

--- a/test/expose-class-on-global.js
+++ b/test/expose-class-on-global.js
@@ -21,6 +21,15 @@ ruleTester.run('expose-class-on-global', rule, {
       ]
     },
     {
+      code: 'class FooBar extends CustomHTMLElement {}',
+      errors: [
+        {
+          message: 'Custom Element has not been exported onto `window`',
+          type: 'ClassDeclaration'
+        }
+      ]
+    },
+    {
       code: 'window.customElements.define("foo-bar", FooBar)\nclass FooBar extends HTMLElement {}',
       errors: [
         {


### PR DESCRIPTION
# Description

This PR just changes the regex to detect elements of the form `^.*HTML.*Element$`. The motivation for this is custom element base classes, such as `VendorHTMLElement`.

# Breaking changes

ESLint rule may be more lenient than before and highlight new warnings.