### PR TITLE
Add option allowedSuperNames for `extends-correct-class`

### DIFF
--- a/docs/rules/extends-correct-class.md
+++ b/docs/rules/extends-correct-class.md
@@ -9,7 +9,7 @@ The [specification defines the requirements of the superclass for each of these 
 
 ## Rule Details
 
-This rule enforces that any call to `customElements.define` must be given the correct superclass. If the `extends` option is passed, then the given classes superclass must match the named element. If the `extends` option is not passed, then the given classes superclass must be `HTMLElement`.
+This rule enforces that any call to `customElements.define` must be given the correct superclass. If the `extends` option is passed, then the given classes superclass must match the named element. If the `extends` option is not passed, then the given classes superclass must be `HTMLElement` or specified by the [`allowedSuperNames` ESLint option](#allowedSuperNames).
 
 👎 Examples of **incorrect** code for this rule:
 
@@ -32,6 +32,10 @@ customElements.define('foo-bar', class extends HTMLElement {})
 ```js
 customElements.define('foo-bar', class extends HTMLParagraphElement {}, {extends: 'p'})
 ```
+
+### Options
+
+- `allowedSuperNames` is an array option (default: []) can specify what classes an Autonomous custom element _may_ extend. It is assumed that by using this option, any allowed super name _must_ extend `HTMLElement` in its prototype chain.
 
 ## When Not To Use It
 

--- a/lib/rules/extends-correct-class.js
+++ b/lib/rules/extends-correct-class.js
@@ -15,12 +15,36 @@ function getExtendsOption(node) {
   return null
 }
 
+/**
+ * Format the array of allowed super names for a given class
+ * into a string for reporting.
+ *
+ * @param {Array<string>} allowedSuperNames
+ * @example
+ * formatNames(['HTMLElement']) // 'HTMLElement'
+ * formatNames(['HTMLElement', 'CustomElement']) // '{HTMLElement, CustomElement}'
+ */
+function formatNames(allowedSuperNames) {
+  if (allowedSuperNames.length === 1) {
+    return allowedSuperNames[0]
+  }
+
+  return `{${allowedSuperNames.join(', ')}}`
+}
+
 module.exports = {
   meta: {
     type: 'problem',
     docs: {description: '', url: require('../url')(module)}
   },
-  schema: [],
+  schema: [
+    {
+      type: 'object',
+      properties: {
+        allowedSuperNames: {type: 'array', items: {type: 'string'}}
+      }
+    }
+  ],
   create(context) {
     const classes = new ClassRefTracker(context)
     return {
@@ -31,29 +55,42 @@ module.exports = {
         const classRef = classes.get(node.arguments[1])
         if (!classRef) return
         const extendsTag = getExtendsOption(node.arguments[2])
-        const desiredSuperName = builtInTagMap[extendsTag] || 'HTMLElement'
+
+        // Allowed super names is an array of allowed names.
+        let allowedSuperNames
+        if (builtInTagMap[extendsTag]) {
+          allowedSuperNames = [builtInTagMap[extendsTag]]
+        } else {
+          allowedSuperNames = [...((context.options[0] || {}).allowedSuperNames || [])]
+          // Make sure to treat this like a set.
+          if (!allowedSuperNames.includes('HTMLElement')) {
+            allowedSuperNames.push('HTMLElement')
+          }
+        }
+
+        const formattedNames = formatNames(allowedSuperNames)
         if (!classRef.superClass) {
-          return context.report(node.arguments[1], `Custom Element must extend ${desiredSuperName}`)
+          return context.report(node.arguments[1], `Custom Element must extend ${formattedNames}`)
         }
         const superName = classRef.superClass.name
-        if (superName !== desiredSuperName) {
+        if (!allowedSuperNames.includes(superName)) {
           const expectedTag = Object.entries(builtInTagMap).find(e => e[1] === superName)?.[0] || null
           if (extendsTag && !expectedTag) {
-            context.report(node, `${superName} !== ${desiredSuperName}`)
+            context.report(node, `${superName} !== ${formattedNames}`)
           } else if (!extendsTag && expectedTag) {
             context.report(
               node,
-              `Custom Element must extend ${desiredSuperName}, or pass {extends:'${expectedTag}'} as a third argument to define`
+              `Custom Element must extend ${formattedNames}, or pass {extends:'${expectedTag}'} as a third argument to define`
             )
           } else if (extendsTag !== expectedTag) {
             context.report(
               node,
               `Custom Element extends ${superName} but the definition includes {extends:'${extendsTag}'}. ` +
-                `Either the Custom Element must extend from ${desiredSuperName}, ` +
+                `Either the Custom Element must extend from ${formattedNames}, ` +
                 `or the definition must include {extends:'${expectedTag}'}.`
             )
           } else {
-            context.report(node, `Custom Element must extend ${desiredSuperName} not ${superName}`)
+            context.report(node, `Custom Element must extend ${formattedNames} not ${superName}`)
           }
         }
       }

--- a/lib/rules/extends-correct-class.js
+++ b/lib/rules/extends-correct-class.js
@@ -24,12 +24,9 @@ function getExtendsOption(node) {
  * formatNames(['HTMLElement']) // 'HTMLElement'
  * formatNames(['HTMLElement', 'CustomElement']) // '{HTMLElement, CustomElement}'
  */
+const formatter = new Intl.ListFormat('en', { style: 'short', type: 'disjunction' })
 function formatNames(allowedSuperNames) {
-  if (allowedSuperNames.length === 1) {
-    return allowedSuperNames[0]
-  }
-
-  return `{${allowedSuperNames.join(', ')}}`
+  return formatter.format(allowedSuperNames)
 }
 
 module.exports = {

--- a/lib/rules/extends-correct-class.js
+++ b/lib/rules/extends-correct-class.js
@@ -24,7 +24,7 @@ function getExtendsOption(node) {
  * formatNames(['HTMLElement']) // 'HTMLElement'
  * formatNames(['HTMLElement', 'CustomElement']) // '{HTMLElement, CustomElement}'
  */
-const formatter = new Intl.ListFormat('en', { style: 'short', type: 'disjunction' })
+const formatter = new Intl.ListFormat('en', {style: 'short', type: 'disjunction'})
 function formatNames(allowedSuperNames) {
   return formatter.format(allowedSuperNames)
 }
@@ -56,13 +56,10 @@ module.exports = {
         // Allowed super names is an array of allowed names.
         let allowedSuperNames
         if (builtInTagMap[extendsTag]) {
-          allowedSuperNames = [builtInTagMap[extendsTag]]
+          allowedSuperNames = new Set([builtInTagMap[extendsTag]])
         } else {
-          allowedSuperNames = [...((context.options[0] || {}).allowedSuperNames || [])]
-          // Make sure to treat this like a set.
-          if (!allowedSuperNames.includes('HTMLElement')) {
-            allowedSuperNames.push('HTMLElement')
-          }
+          allowedSuperNames = new Set((context.options[0] || {}).allowedSuperNames || [])
+          allowedSuperNames.add('HTMLElement')
         }
 
         const formattedNames = formatNames(allowedSuperNames)
@@ -70,7 +67,7 @@ module.exports = {
           return context.report(node.arguments[1], `Custom Element must extend ${formattedNames}`)
         }
         const superName = classRef.superClass.name
-        if (!allowedSuperNames.includes(superName)) {
+        if (!allowedSuperNames.has(superName)) {
           const expectedTag = Object.entries(builtInTagMap).find(e => e[1] === superName)?.[0] || null
           if (extendsTag && !expectedTag) {
             context.report(node, `${superName} !== ${formattedNames}`)

--- a/lib/rules/extends-correct-class.js
+++ b/lib/rules/extends-correct-class.js
@@ -22,7 +22,7 @@ function getExtendsOption(node) {
  * @param {Array<string>} allowedSuperNames
  * @example
  * formatNames(['HTMLElement']) // 'HTMLElement'
- * formatNames(['HTMLElement', 'CustomElement']) // '{HTMLElement, CustomElement}'
+ * formatNames(['HTMLElement', 'CustomElement']) // HTMLElement or CustomElement
  */
 const formatter = new Intl.ListFormat('en', {style: 'short', type: 'disjunction'})
 function formatNames(allowedSuperNames) {

--- a/test/extends-correct-class.js
+++ b/test/extends-correct-class.js
@@ -7,7 +7,15 @@ ruleTester.run('extends-correct-class', rule, {
   valid: [
     {code: 'customElements.define("foo-bar", class extends HTMLElement {})'},
     {code: 'customElements.define("foo-bar", class extends HTMLDivElement {}, { extends: "div" })'},
-    {code: 'customElements.define("foo-bar", class extends HTMLOListElement {}, { extends: `ol` })'}
+    {code: 'customElements.define("foo-bar", class extends HTMLOListElement {}, { extends: `ol` })'},
+    {
+      code: 'customElements.define("foo-bar", class extends HTMLGitHubElement {})',
+      options: [{allowedSuperNames: ['HTMLGitHubElement']}]
+    },
+    {
+      code: 'customElements.define("foo-bar", class extends HTMLElement {})',
+      options: [{allowedSuperNames: ['HTMLGitHubElement']}]
+    }
   ],
   invalid: [
     {
@@ -52,6 +60,27 @@ ruleTester.run('extends-correct-class', rule, {
         {
           message:
             "Custom Element extends HTMLDivElement but the definition includes {extends:'p'}. Either the Custom Element must extend from HTMLParagraphElement, or the definition must include {extends:'div'}.",
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      code: 'customElements.define("foo-bar", class extends HTMLGitHubElement {}, { extends: `ol` })',
+      options: [{allowedSuperNames: ['HTMLGitHubElement']}],
+      errors: [
+        {
+          message: 'HTMLGitHubElement !== HTMLOListElement',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
+      code: 'customElements.define("foo-bar", class extends HTMLGitHubThreeElement {})',
+      options: [{allowedSuperNames: ['HTMLGitHubOneElement', 'HTMLGitHubTwoElement']}],
+      errors: [
+        {
+          message:
+            'Custom Element must extend {HTMLGitHubOneElement, HTMLGitHubTwoElement, HTMLElement} not HTMLGitHubThreeElement',
           type: 'CallExpression'
         }
       ]

--- a/test/extends-correct-class.js
+++ b/test/extends-correct-class.js
@@ -80,7 +80,7 @@ ruleTester.run('extends-correct-class', rule, {
       errors: [
         {
           message:
-            'Custom Element must extend {HTMLGitHubOneElement, HTMLGitHubTwoElement, HTMLElement} not HTMLGitHubThreeElement',
+            'Custom Element must extend HTMLGitHubOneElement, HTMLGitHubTwoElement, or HTMLElement not HTMLGitHubThreeElement',
           type: 'CallExpression'
         }
       ]


### PR DESCRIPTION
Closes #32

# Description

This adds an option `allowedSuperNames` to the `extends-correct-class` rule that an Autonomous custom element _may_ extend. It is assumed that by using this option, any allowed super name _must_ extend `HTMLElement` in its prototype chain.