### PR TITLE
Limit `no-customized-built-in-elements` to built ins

### DIFF
--- a/lib/rules/no-customized-built-in-elements.js
+++ b/lib/rules/no-customized-built-in-elements.js
@@ -1,4 +1,6 @@
 const s = require('../custom-selectors')
+const {builtInTagMap} = require('../tag-names')
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -8,7 +10,11 @@ module.exports = {
   create(context) {
     return {
       [s.HTMLElementClass](node) {
-        if (node.superClass && node.superClass.name !== 'HTMLElement') {
+        if (
+          node.superClass &&
+          node.superClass.name !== 'HTMLElement' &&
+          Object.values(builtInTagMap).includes(node.superClass.name)
+        ) {
           context.report(node, 'Avoid extending built-in elements')
         }
       }

--- a/test/no-customized-built-in-elements.js
+++ b/test/no-customized-built-in-elements.js
@@ -7,7 +7,8 @@ ruleTester.run('no-customized-built-in-elements', rule, {
     {code: 'class SomeMap extends Map { }'},
     {code: 'class FooBarElement { }'},
     {code: 'class FooBarElement extends HTMLElement { }'},
-    {code: 'const FooBarElement = class extends HTMLElement { }'}
+    {code: 'const FooBarElement = class extends HTMLElement { }'},
+    {code: 'const FooBarElement = class extends HTMLRandomNotBuiltInElement { }'}
   ],
   invalid: [
     {


### PR DESCRIPTION
# Description

This PR changes `no-customized-built-in-elements` to only error if the extended class is a value of `builtInTagMap` (except `HTMLElement`, of course). 

```javascript
          node.superClass &&
          node.superClass.name !== 'HTMLElement' &&
          Object.values(builtInTagMap).includes(node.superClass.name)
```

The main motivation behind this work is extending a class that itself extends `HTMLElement`, without the complexity of static analyzing.

# Alternatives

Alternatively to this PR, users could just turn this rule off, but would lose slight benefit.

We could also have an allowlist for this rule, `allowedSuperNames`, similar to https://github.com/github/eslint-plugin-custom-elements/pull/38

# Breaking changes

This may change the actual (not expected) behavior of no-customized-built-in-elements in slight ways