### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/name-transforms.js
+++ b/lib/name-transforms.js
@@ -20,22 +20,22 @@ module.exports = {
   *generateNames(prefixes, suffixes, name) {
     for (const prefix of prefixes) {
       if (name.toLowerCase().startsWith(prefix.toLowerCase())) {
-        const truncated = name.substr(prefix.length)
+        const truncated = name.slice(prefix.length)
         yield truncated
         for (const suffix of suffixes) {
           if (truncated.toLowerCase().endsWith(suffix.toLowerCase())) {
-            yield truncated.substr(0, truncated.length - suffix.length)
+            yield truncated.slice(0, truncated.length - suffix.length)
           }
         }
       }
     }
     for (const suffix of suffixes) {
       if (name.toLowerCase().endsWith(suffix.toLowerCase())) {
-        const truncated = name.substr(0, name.length - suffix.length)
+        const truncated = name.slice(0, name.length - suffix.length)
         yield truncated
         for (const prefix of prefixes) {
           if (truncated.toLowerCase().startsWith(prefix.toLowerCase())) {
-            yield truncated.substr(prefix.length)
+            yield truncated.slice(prefix.length)
           }
         }
       }

--- a/test/check-rules.js
+++ b/test/check-rules.js
@@ -18,7 +18,7 @@ function rulesFromDir(dir) {
 function makeTitle(name) {
   return name
     .replace(/-/g, ' ')
-    .replace(/\w\S*/g, x => x.charAt(0).toUpperCase() + x.substr(1))
+    .replace(/\w\S*/g, x => x.charAt(0).toUpperCase() + x.slice(1))
     .replace(/\b(The|An?|And|To|In|On|With)\b/g, x => x.toLowerCase())
     .replace(/\b(Dom)\b/g, x => x.toUpperCase())
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.