### PR TITLE
Allow logical expression in if statement

### DIFF
--- a/lib/rules/no-unchecked-define.js
+++ b/lib/rules/no-unchecked-define.js
@@ -11,7 +11,9 @@ module.exports = {
   create(context) {
     definedCustomElements = new Map()
     return {
-      [`IfStatement:matches([test.type=UnaryExpression],[test.type=BinaryExpression]) ${s.customElements.get}`](node) {
+      [`IfStatement:matches([test.type=UnaryExpression],[test.type=BinaryExpression],[test.type=LogicalExpression]) ${s.customElements.get}`](
+        node
+      ) {
         if (node.parent.type === 'UnaryExpression') {
           let unaryCounter = 0
           let parent = node.parent

--- a/lib/rules/no-unchecked-define.js
+++ b/lib/rules/no-unchecked-define.js
@@ -24,6 +24,10 @@ module.exports = {
           if (unaryCounter % 2 !== 0) {
             definedCustomElements.set(node.arguments[0].value, node)
           }
+        } else if (node.parent.type === 'LogicalExpression') {
+          // Don't do anything. If the parent is a logical expression, we are
+          // checking for truthiness and we only care about if the element is
+          // _not_ defined.
         } else {
           definedCustomElements.set(node.arguments[0].value, node)
         }

--- a/test/no-unchecked-define.js
+++ b/test/no-unchecked-define.js
@@ -8,6 +8,9 @@ ruleTester.run('no-unchecked-define', rule, {
       code: 'if (!window.customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } '
     },
     {
+      code: 'if (window.customElements && !window.customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } '
+    },
+    {
       code: 'if (!customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } '
     },
     {

--- a/test/no-unchecked-define.js
+++ b/test/no-unchecked-define.js
@@ -45,6 +45,16 @@ ruleTester.run('no-unchecked-define', rule, {
       ]
     },
     {
+      code: 'if (window.customElements && customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } ',
+      errors: [
+        {
+          message:
+            'Make sure to wrap customElements.define calls in checks to see if the element has already been defined',
+          type: 'CallExpression'
+        }
+      ]
+    },
+    {
       code: 'if (!customElements.get("bar-foo")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } ',
       errors: [
         {


### PR DESCRIPTION
Consider these two code-snippets:

```js
if (window && !window.customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) }
```

```js
if (window && window.customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) }
```

In both cases, the if statement has the type `LogicalExpression`, which we weren't checking for in our lint rule. Additionally, in the former snippet, the `customElements.get` call is a `UnaryExpression` and gets handled by our existing code. Still, the parent is just a `LogicalExpression` in the second snippet. So we make sure to _not_ register the element if its parent is a `LogicalExpression`.