### PR TITLE
allow defining custom elements in a try/catch

### DIFF
--- a/lib/rules/no-unchecked-define.js
+++ b/lib/rules/no-unchecked-define.js
@@ -33,9 +33,16 @@ module.exports = {
         }
       },
       [s.customElements.define](node) {
+        const inTryCatch =
+          node.parent &&
+          node.parent.type === 'ExpressionStatement' &&
+          node.parent.parent &&
+          node.parent.parent.type === 'BlockStatement' &&
+          node.parent.parent.parent &&
+          node.parent.parent.parent.type === 'TryStatement'
         if (definedCustomElements.has(node.arguments[0].value)) {
           definedCustomElements.delete(node.arguments[0].value)
-        } else {
+        } else if (!inTryCatch) {
           context.report(
             node,
             'Make sure to wrap customElements.define calls in checks to see if the element has already been defined'

--- a/test/no-unchecked-define.js
+++ b/test/no-unchecked-define.js
@@ -22,6 +22,12 @@ ruleTester.run('no-unchecked-define', rule, {
     {
       code: 'if (!!!customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } ',
     },
+    {
+      code: 'try { window.customElements.define("foo-bar", class extends HTMLElement {}) } catch {}',
+    },
+    {
+      code: 'try { window.customElements.define("foo-bar", class extends HTMLElement {}) } catch (e) {}',
+    },
   ],
   invalid: [
     {
@@ -76,6 +82,26 @@ ruleTester.run('no-unchecked-define', rule, {
     },
     {
       code: 'if (!!customElements.get("foo-bar")) { window.customElements.define("foo-bar", class extends HTMLElement {}) } ',
+      errors: [
+        {
+          message:
+            'Make sure to wrap customElements.define calls in checks to see if the element has already been defined',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'try { } catch { customElements.define("foo-bar", class extends HTMLElement {}) }',
+      errors: [
+        {
+          message:
+            'Make sure to wrap customElements.define calls in checks to see if the element has already been defined',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'try { } catch (e) { customElements.define("foo-bar", class extends HTMLElement {}) }',
       errors: [
         {
           message:


### PR DESCRIPTION
This relaxes the `no-unchecked-define` rule to allow for `customElements.define` calls that exist within a `try/catch` block. We've found the `try/catch` pattern to be helpful when defining elements within the context of a custom elements HMR plugin, that expects you to call `define()` on each load.

See https://github.com/github/relative-time-element/pull/209 and https://github.com/github/catalyst/pull/197 for more.