### PR TITLE
relax extends-correct-class rule for imports

### DIFF
--- a/lib/rules/extends-correct-class.js
+++ b/lib/rules/extends-correct-class.js
@@ -51,6 +51,7 @@ module.exports = {
       [s.customElements.define](node) {
         const classRef = classes.get(node.arguments[1])
         if (!classRef) return
+        if (classRef.type === 'ImportDefaultSpecifier' || classRef.type === 'ImportSpecifier') return
         const extendsTag = getExtendsOption(node.arguments[2])
 
         // Allowed super names is an array of allowed names.

--- a/test/extends-correct-class.js
+++ b/test/extends-correct-class.js
@@ -1,7 +1,7 @@
 const rule = require('../lib/rules/extends-correct-class')
 const RuleTester = require('eslint').RuleTester
 
-const ruleTester = new RuleTester({env: {es2020: true}})
+const ruleTester = new RuleTester({env: {es2020: true}, parserOptions: {sourceType: 'module'}})
 
 ruleTester.run('extends-correct-class', rule, {
   valid: [
@@ -15,6 +15,12 @@ ruleTester.run('extends-correct-class', rule, {
     {
       code: 'customElements.define("foo-bar", class extends HTMLElement {})',
       options: [{allowedSuperNames: ['HTMLGitHubElement']}]
+    },
+    {
+      code: 'import Foo from "other";customElements.define("foo-bar", Foo)'
+    },
+    {
+      code: 'import {Foo} from "other";customElements.define("foo-bar", Foo)'
     }
   ],
   invalid: [


### PR DESCRIPTION
When using the `extends-correct-class` rule with an imported class, it is not possible to determine the superclass from the import statement alone. 

Currently, we fail the check because the `classRefTracker` will track the Import Specifier, which will not have a `superClass` property (as its an `Identifier` not a `ClassDefinition`). This means that the rule, when turned on, fails on imported classes.

This PR changes this to guard against linting identifiers which come from an `ImportDefaultSpecifier` or `ImportSpecifier`. The guard returns early, so the check is skipped. This means that the rule, when turned on, will no longer fail on imported classes.