### PR TITLE
move schemas into meta

### DIFF
--- a/lib/rules/define-tag-after-class-definition.js
+++ b/lib/rules/define-tag-after-class-definition.js
@@ -4,8 +4,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     const classes = ClassRefTracker.customElements(context)
     return {

--- a/lib/rules/expose-class-on-global.js
+++ b/lib/rules/expose-class-on-global.js
@@ -4,8 +4,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     const classes = ClassRefTracker.customElements(context)
     return {

--- a/lib/rules/extends-correct-class.js
+++ b/lib/rules/extends-correct-class.js
@@ -33,15 +33,15 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {description: '', url: require('../url')(module)},
-  },
-  schema: [
-    {
-      type: 'object',
-      properties: {
-        allowedSuperNames: {type: 'array', items: {type: 'string'}},
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowedSuperNames: {type: 'array', items: {type: 'string'}},
+        },
       },
-    },
-  ],
+    ],
+  },
   create(context) {
     const classes = new ClassRefTracker(context)
     return {

--- a/lib/rules/file-name-matches-element.js
+++ b/lib/rules/file-name-matches-element.js
@@ -19,31 +19,31 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
-  },
-  schema: [
-    {
-      type: 'object',
-      properties: {
-        transform: {
-          oneOf: [
-            {enum: ['none', 'snake', 'kebab', 'pascal']},
-            {
-              type: 'array',
-              items: {enum: ['none', 'snake', 'kebab', 'pascal']},
-              minItems: 1,
-              maxItems: 4,
-            },
-          ],
-        },
-        suffix: {
-          onfOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
-        },
-        matchDirectory: {
-          type: 'boolean',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          transform: {
+            oneOf: [
+              {enum: ['none', 'snake', 'kebab', 'pascal']},
+              {
+                type: 'array',
+                items: {enum: ['none', 'snake', 'kebab', 'pascal']},
+                minItems: 1,
+                maxItems: 4,
+              },
+            ],
+          },
+          suffix: {
+            onfOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+          },
+          matchDirectory: {
+            type: 'boolean',
+          },
         },
       },
-    },
-  ],
+    ],
+  },
   create(context) {
     if (!hasFileName(context)) return {}
     return {

--- a/lib/rules/no-constructor.js
+++ b/lib/rules/no-constructor.js
@@ -3,8 +3,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     return {
       [`${s.HTMLElementClass} MethodDefinition[key.name="constructor"]`](node) {

--- a/lib/rules/no-customized-built-in-elements.js
+++ b/lib/rules/no-customized-built-in-elements.js
@@ -5,8 +5,8 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     return {
       [s.HTMLElementClass](node) {

--- a/lib/rules/no-dom-traversal-in-attributechangedcallback.js
+++ b/lib/rules/no-dom-traversal-in-attributechangedcallback.js
@@ -4,8 +4,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     return {
       [`${s.HTMLElementClass} MethodDefinition[key.name="attributeChangedCallback"] MemberExpression`](node) {

--- a/lib/rules/no-dom-traversal-in-connectedcallback.js
+++ b/lib/rules/no-dom-traversal-in-connectedcallback.js
@@ -4,8 +4,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     return {
       [`${s.HTMLElementClass} MethodDefinition[key.name="connectedCallback"] MemberExpression`](node) {

--- a/lib/rules/no-exports-with-element.js
+++ b/lib/rules/no-exports-with-element.js
@@ -5,8 +5,8 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     const classes = ClassRefTracker.customElements(context)
     const eventClasses = ClassRefTracker.customEvents(context)

--- a/lib/rules/no-method-prefixed-with-on.js
+++ b/lib/rules/no-method-prefixed-with-on.js
@@ -4,8 +4,8 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     return {
       [`${s.HTMLElementClass} MethodDefinition[key.name=/^on.*$/i]`](node) {

--- a/lib/rules/no-unchecked-define.js
+++ b/lib/rules/no-unchecked-define.js
@@ -6,8 +6,8 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     definedCustomElements = new Map()
     return {

--- a/lib/rules/one-element-per-file.js
+++ b/lib/rules/one-element-per-file.js
@@ -3,8 +3,8 @@ module.exports = {
   meta: {
     type: 'layout',
     docs: {description: '', url: require('../url')(module)},
+    schema: [],
   },
-  schema: [],
   create(context) {
     let classCount = 0
     return {

--- a/lib/rules/tag-name-matches-class.js
+++ b/lib/rules/tag-name-matches-class.js
@@ -19,20 +19,20 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {description: '', url: require('../url')(module)},
-  },
-  schema: [
-    {
-      type: 'object',
-      properties: {
-        suffix: {
-          onfOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
-        },
-        prefix: {
-          onfOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          suffix: {
+            onfOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+          },
+          prefix: {
+            onfOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+          },
         },
       },
-    },
-  ],
+    ],
+  },
   create(context) {
     return {
       [s.customElements.define](node) {

--- a/lib/rules/valid-tag-name.js
+++ b/lib/rules/valid-tag-name.js
@@ -4,22 +4,22 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {description: '', url: require('../url')(module)},
-  },
-  schema: [
-    {
-      type: 'object',
-      properties: {
-        disallowNamespaces: {type: 'boolean'},
-        onlyAlphanum: {type: 'boolean'},
-        prefix: {
-          oneOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
-        },
-        suffix: {
-          oneOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          disallowNamespaces: {type: 'boolean'},
+          onlyAlphanum: {type: 'boolean'},
+          prefix: {
+            oneOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+          },
+          suffix: {
+            oneOf: [{type: 'string'}, {type: 'array', items: {type: 'string'}}],
+          },
         },
       },
-    },
-  ],
+    ],
+  },
   create(context) {
     return {
       [s.customElements.define](node) {

--- a/test/check-rules.js
+++ b/test/check-rules.js
@@ -124,7 +124,7 @@ describe('documentation', () => {
         '## Rule Details',
         '👎 Examples of **incorrect** code for this rule:',
         '👍 Examples of **correct** code for this rule:',
-        config.rules?.[doc]?.schema?.length ? '### Options' : '',
+        config.rules?.[doc]?.meta.schema?.length ? '### Options' : '',
         '## When Not To Use It',
         '## Version',
       ].filter(Boolean)


### PR DESCRIPTION
https://eslint.org/docs/latest/developer-guide/working-with-rules#options-schemas 

`schema` needs to be in `meta`. We've incorrectly been putting it with the rules main object. You can see in our logs: https://github.com/github/eslint-plugin-custom-elements/actions/runs/3829378144/jobs/6516011787#step:4:212 that eslint does not correctly get the schema. It seems as though v9 of eslint will require schemas (https://github.com/eslint/rfcs/pull/85). So this should resolve issues around v9.