### PR TITLE
add eslint-plugin-eslint-plugin and fix failures

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,10 +6,11 @@ module.exports = {
   env: {
     node: true,
   },
-  extends: ['plugin:github/recommended'],
+  extends: ['plugin:github/recommended', 'plugin:eslint-plugin/recommended'],
   rules: {
     'i18n-text/no-en': 'off',
     'import/no-commonjs': 'off',
+    'eslint-plugin/require-meta-docs-url': 'error',
   },
   overrides: [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "eslint": "^8.28.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
+        "eslint-plugin-eslint-plugin": "^5.0.7",
         "eslint-plugin-github": "^4.4.1",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -1088,6 +1089,31 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.0.7.tgz",
+      "integrity": "sha512-hcz4Bze1ECwv3Q/Bi/ZMZZNiuvI2YclNuxjnczkblQ0skrlPhdO83rSM7felf5n+7ZJOZi4GS8y8gNiRtvI0hA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^3.0.0",
+        "estraverse": "^5.3.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-eslint-plugin/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/eslint-plugin-filenames": {
@@ -4100,6 +4126,24 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-eslint-plugin": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-5.0.7.tgz",
+      "integrity": "sha512-hcz4Bze1ECwv3Q/Bi/ZMZZNiuvI2YclNuxjnczkblQ0skrlPhdO83rSM7felf5n+7ZJOZi4GS8y8gNiRtvI0hA==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^3.0.0",
+        "estraverse": "^5.3.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-eslint-plugin": "^5.0.7",
     "eslint-plugin-github": "^4.4.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/test/file-name-matches-element.js
+++ b/test/file-name-matches-element.js
@@ -38,7 +38,6 @@ ruleTester.run('file-name-matches-element', rule, {
     {code, filename: 'foo_bar.js', options: [{transform: ['kebab', 'snake', 'pascal'], suffix: 'Element'}]},
     {code, filename: 'foo_bar_element.js', options: [{transform: ['kebab', 'snake'], suffix: ['Element']}]},
     {code, filename: 'fooBarElement.js', options: [{transform: ['kebab', 'pascal'], suffix: ['ElEmEnT']}]},
-    {code, filename: 'foo_bar_element.js', options: [{transform: ['kebab', 'snake'], suffix: ['Element']}]},
     {code, filename: 'bar_element.js', options: [{transform: ['kebab', 'snake'], prefix: ['Foo']}]},
     {code, filename: 'bar_element.js', options: [{transform: ['kebab', 'snake'], prefix: ['fOo']}]},
     {

--- a/test/tag-name-matches-class.js
+++ b/test/tag-name-matches-class.js
@@ -8,7 +8,6 @@ ruleTester.run('tag-name-matches-class', rule, {
     {code: "customElements.define('foo-bar-element', FooBarElement)"},
     {code: "customElements.define('foo-bar', FooBar)", options: [{suffix: ['Element']}]},
     {code: "customElements.define('foo-bar', FooBarElement)", options: [{suffix: ['Element']}]},
-    {code: "customElements.define('foo-bar', FooBarElement)", options: [{suffix: ['Element']}]},
     {code: "customElements.define('foo-bar', FooBarComponent)", options: [{suffix: 'Component'}]},
     {code: "customElements.define('foo-bar', FooBarElement)", options: [{suffix: ['Element', 'Component']}]},
     {code: "customElements.define('foo-bar', FooBarComponent)", options: [{suffix: ['Element', 'Component']}]},

--- a/test/valid-tag-name.js
+++ b/test/valid-tag-name.js
@@ -8,7 +8,6 @@ ruleTester.run('valid-tag-name', rule, {
     {code: 'customElements.define("foo-bar")'},
     {code: "customElements.define('foo-bar')"},
     {code: 'customElements.define(`foo-bar`)'},
-    {code: 'customElements.define("foo-bar")'},
     {code: 'customElements.define("m---···---")'},
     {code: 'customElements.define("aÀ-")'},
     {code: 'customElements.define("leiðinlegt-tíst")'},
@@ -86,20 +85,6 @@ ruleTester.run('valid-tag-name', rule, {
       errors: [
         {
           message: 'Custom Elements cannot be given the reserved name "annotation-xml"',
-          type: 'Literal',
-        },
-      ],
-    },
-    {
-      code: 'customElements.define("a-😶‍🌫️")',
-      options: [
-        {
-          onlyAlphanum: true,
-        },
-      ],
-      errors: [
-        {
-          message: 'Non ASCII Custom Elements have been disallowed',
           type: 'Literal',
         },
       ],


### PR DESCRIPTION
This adds the `eslint-plugin-eslint-plugin` recommended config, to ensure we're authoring plugins correctly.

It managed to catch a few duplicate test cases, so I've removed those too.