### PR TITLE
file-name-matches-element: Fix case of missing name

### DIFF
--- a/lib/rules/file-name-matches-element.js
+++ b/lib/rules/file-name-matches-element.js
@@ -48,8 +48,11 @@ module.exports = {
     if (!hasFileName(context)) return {}
     return {
       [s.HTMLElementClass](node) {
-        const name = node.id.name
-        const names = [name]
+        const name = node.id?.name
+        const names = []
+        if (name) {
+          names.push(name)
+        }
         const filename = basename(context.getFilename(), extname(context.getFilename()))
         const transforms = [].concat(context.options?.[0]?.transform || ['kebab', 'pascal'])
         const suffixes = [].concat(context.options?.[0]?.suffix || [])
@@ -66,7 +69,7 @@ module.exports = {
             allowedFileNames.add(transformFuncs[transform](className))
           }
         }
-        if (!allowedFileNames.has(filename)) {
+        if (allowedFileNames.size && !allowedFileNames.has(filename)) {
           const allowed = Array.from(allowedFileNames).join('" or "')
           context.report(node, `File name should be "${allowed}" but was "${filename}"`)
         }

--- a/test/file-name-matches-element.js
+++ b/test/file-name-matches-element.js
@@ -51,6 +51,10 @@ ruleTester.run('file-name-matches-element', rule, {
       filename: 'components/foo/foo-bar.ts',
       options: [{transform: 'kebab', suffix: ['Controller']}],
     },
+    {
+      code: 'window.customElements.define("foo-bar", class extends HTMLElement {})',
+      filename: 'any.js',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fix parsing of anonymous class expression, ignore it if no name can be derived.

Fixes: https://github.com/github/eslint-plugin-custom-elements/issues/57